### PR TITLE
chore: change rstudio/connectapi to posit-dev/connectapi

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,9 +15,9 @@ This has some additional requirements.
 
 - You need a valid Connect license key or file. Put the contents of the license key, or the path to the license file, in the `RSC_LICENSE` environment variable.
 - You need Docker.
-- If you're running on an ARM (non-Intel) Mac, `export DOCKER_DEFAULT_PLATFORM=linux/amd64` 
+- If you're running on an ARM (non-Intel) Mac, `export DOCKER_DEFAULT_PLATFORM=linux/amd64`
 - Run `connectapi:::build_test_env()` to set up the Connect processes in docker
-- By default, this will run against a contemporary version of Connect. To test against an older version, set the environment variable `CONNECT_VERSION` to something else and then run `build_test_env()`. 
+- By default, this will run against a contemporary version of Connect. To test against an older version, set the environment variable `CONNECT_VERSION` to something else and then run `build_test_env()`.
 - Set `CONNECTAPI_INTEGRATED=true` in the environment to enable running the integration tests (they're skipped by default).
 - Run them with `source("tests/test-integrated.R")`
 
@@ -35,7 +35,7 @@ If you’ve found a bug, please file an issue that illustrates the bug with a mi
 
 ### Pull request process
 
-*   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("rstudio/connectapi", fork = TRUE)`.
+*   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("posit-dev/connectapi", fork = TRUE)`.
 
 *   Install all development dependencies with `devtools::install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`.
     If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -16,12 +16,12 @@ Armed with your reprex, the next step is to figure out [where to ask](https://ww
 
 *   If it's a question: start with [forum.posit.co](https://forum.posit.co/), and/or StackOverflow. There are more people there to answer questions.
 
-*   If it's a bug: you're in the right place, [file an issue](https://github.com/rstudio/connectapi/issues/new).
+*   If it's a bug: you're in the right place, [file an issue](https://github.com/posit-dev/connectapi/issues/new).
 
 *   If you're not sure: let the community help you figure it out!
     If your problem _is_ a bug or a feature request, you can easily return here and report it.
 
-Before opening a new issue, be sure to [search issues and pull requests](https://github.com/rstudio/connectapi/issues) to make sure the bug hasn't been reported and/or already fixed in the development version.
+Before opening a new issue, be sure to [search issues and pull requests](https://github.com/posit-dev/connectapi/issues) to make sure the bug hasn't been reported and/or already fixed in the development version.
 By default, the search will be pre-populated with `is:issue is:open`.
 You can [edit the qualifiers](https://help.github.com/articles/searching-issues-and-pull-requests/)  (e.g. `is:pr`, `is:closed`) as needed.
 For example, you'd simply remove `is:open` to search _all_ issues in the repo, open or closed.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Description: Provides a helpful 'R6' class and methods for interacting with
     and version, but the latest documentation is also hosted publicly at
     <https://docs.posit.co/connect/api/>.
 License: MIT + file LICENSE
-URL: https://pkgs.rstudio.com/connectapi/, https://github.com/posit-dev/connectapi
+URL: https://posit-dev.github.io/connectapi/, https://github.com/posit-dev/connectapi
 BugReports: https://github.com/posit-dev/connectapi/issues
 Imports:
     bit64,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,8 @@ Description: Provides a helpful 'R6' class and methods for interacting with
     and version, but the latest documentation is also hosted publicly at
     <https://docs.posit.co/connect/api/>.
 License: MIT + file LICENSE
-URL: https://pkgs.rstudio.com/connectapi/, https://github.com/rstudio/connectapi
-BugReports: https://github.com/rstudio/connectapi/issues
+URL: https://pkgs.rstudio.com/connectapi/, https://github.com/posit-dev/connectapi
+BugReports: https://github.com/posit-dev/connectapi/issues
 Imports:
     bit64,
     fs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -124,7 +124,7 @@
 - `Content$tag_delete()` removes the tag from the target content item rather
   than removing the tag entirely. (#194)
 - `audit_r_versions()` returns a bar chart instead of a histogram (#179)
-- Fix issue with `NULL` or `length 1` job outputs ([#193](https://github.com/posit-dev/connectapi/issues/193))
+- Fix issue with `NULL` or `length 1` job outputs (#193)
 - Timestamp parsing now correctly preserves time components (#259)
 
 # connectapi 0.1.3.1
@@ -140,13 +140,13 @@
 # connectapi 0.1.2
 
 - Update docs to illustrate customizing HTTP requests
-([#168](https://github.com/posit-dev/connectapi/pull/168))
+(#168)
 - Fix issue with HTML documentation to retain on CRAN
-([#164](https://github.com/posit-dev/connectapi/pull/164))
+(#164)
 - Fix typo in `min_data_version` parameter for usage data functions
-([#166](https://github.com/posit-dev/connectapi/pull/166))
+(#166)
 - Bump Connect tested version to 2022.09.0
-  ([#170](https://github.com/posit-dev/connectapi/pull/170))
+  (#170)
 
 # connectapi 0.1.1.1
 
@@ -154,7 +154,7 @@
 
 - BREAKING: the following functions now require RStudio Connect 1.8.6 or later
 (because they are no longer experimental, as of that release).
-([#128](https://github.com/posit-dev/connectapi/pulls/12))
+(#128)
     - `set_vanity_url()`, `get_vanity_url()`, `swap_vanity_url()`
     - `get_tags()`, `get_tag_data()`, `get_content_tags()`, `create_tag()`,
     `create_tag_tree()`, `delete_tag()`, `get_content_tags()`,
@@ -165,16 +165,16 @@
 - BREAKING: `Connect$new()` now takes a `server` argument (instead of `host`)
     - The same is true of the `connect()` function, although we warn about
     argument deprecation in that case.
-    ([#125](https://github.com/posit-dev/connectapi/pulls/125))
+    (#125)
 - BREAKING: `set_environment_new()` and `set_environment_remove()` no longer
   take a `.version` argument, and output data structure is a bit different (a
   list of names). They now use the public API, which changes the interface a bit.
   Also, intricacies of how to set / remove environment variables are changed (i.e.
   setting `VAR=NA` will remove `VAR`).
-  ([#141](https://github.com/posit-dev/connectapi/pull/141))
+  (#141)
 - BREAKING: `get_vanity_url()` and `set_vanity_url()` are now no longer
   experimental functions.
-  ([#113](https://github.com/posit-dev/connectapi/pulls/113)) However:
+  (#113) However:
     - `get_vanity_url()` now returns a character string representing the vanity
     url in use (or NULL if not defined)
     - `set_vanity_url()` still returns a `Vanity` R6 object, but
@@ -184,15 +184,15 @@
 - BREAKING: Several `content_*` and other APIs have moved from experimental to
   "v1" variants. This means they have stabilized, but with several subtle breaking
   changes that could impact your scripts.
-  ([#115](https://github.com/posit-dev/connectapi/pulls/115))
+  (#115)
     - i.e. `bundle_id` has become `id` in some response data. In others, `url` has become `content_url`.
     - The R6 method `content$get_bundles()` no longer takes a `page_number`
     argument, and the `get_bundles(limit)` argument is now deprecated
-    ([#129](https://github.com/posit-dev/connectapi/pulls/129))
+    (#129)
     - `Connect$download_bundle` is now deprecated in favor of
     `Content$bundle_download()`, and `delete_bundle()` now takes a `Content`
     item instead of `Connect`.
-    ([#153](https://github.com/posit-dev/connectapi/pull/153))
+    (#153)
 - BREAKING: `acl_*()` functions are deprecated in favor of
   `get_content_permissions()`, `content_add_user()`, and friends.
 - BREAKING: `Connect$PUT()`, `Connect$POST()` and `Connect$PATCH()` endpoints
@@ -203,29 +203,29 @@
 ### Other Changes
 
 - `users_create_remote()` gains an `exact` argument to simplify complex cases
-  ([#135](https://github.com/posit-dev/connectapi/issues/135)). Long term, we should
+  (#135). Long term, we should
   solicit feedback on whether this function attempts to do too much.
 - Add helpers for common content modification actions: `content_update()`,
   `content_update_access_type()` and `content_update_owner()`
 - Fix an issue with relative paths in `bundle_dir()`
   ([`@slodge`](https://github.com/slodge))
-  ([#118](https://github.com/posit-dev/connectapi/issues/118),
-  [#121](https://github.com/posit-dev/connectapi/issues/121))
+  (#118,
+  #121)
 - Add `overwrite=` parameter to `download_bundle()`
 - Add HTTP request customization options, and related documentation
-  ([#101](https://github.com/posit-dev/connectapi/pull/101))
-- Add git deployment ([#112](https://github.com/posit-dev/connectapi/issues/112))
+  (#101)
+- Add git deployment (#112)
 - Switch `Task` class to `ContentTask`
     - R6 does not support multiple inheritance, so we keep the `Task` interface up-to-date on
       `ContentTask` and `VariantTask` manually
 - Improve several print methods
-([#18](https://github.com/posit-dev/connectapi/issues/18),
-[#19](https://github.com/posit-dev/connectapi/issues/19))
+(#18,
+#19)
 - Protect against bad bundles
-([#13](https://github.com/posit-dev/connectapi/issues/13))
-- Error if an empty API key is defined ([#16](https://github.com/posit-dev/connectapi/issues/16))
+(#13)
+- Error if an empty API key is defined (#16)
 - Add a few `content_list_*` helpers
-  ([#130](https://github.com/posit-dev/connectapi/pulls/130)):
+  (#130):
   - `content_list_with_permissions` returns a `content_list` with a "permission"
     column that includes who has access
   - `content_list_by_tag` allows fetching just a `content_list` for a particular tag
@@ -233,7 +233,7 @@
     whether a user or group GUID has access
 - Add a `user_guid_from_username()` function to convert `session$user` or other
   usernames to a user GUID
-  ([#130](https://github.com/posit-dev/connectapi/pulls/130))
+  (#130)
 
 # connectapi 0.1.0.9018
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -124,7 +124,7 @@
 - `Content$tag_delete()` removes the tag from the target content item rather
   than removing the tag entirely. (#194)
 - `audit_r_versions()` returns a bar chart instead of a histogram (#179)
-- Fix issue with `NULL` or `length 1` job outputs ([#193](https://github.com/rstudio/connectapi/issues/193))
+- Fix issue with `NULL` or `length 1` job outputs ([#193](https://github.com/posit-dev/connectapi/issues/193))
 - Timestamp parsing now correctly preserves time components (#259)
 
 # connectapi 0.1.3.1
@@ -140,13 +140,13 @@
 # connectapi 0.1.2
 
 - Update docs to illustrate customizing HTTP requests
-([#168](https://github.com/rstudio/connectapi/pull/168))
+([#168](https://github.com/posit-dev/connectapi/pull/168))
 - Fix issue with HTML documentation to retain on CRAN
-([#164](https://github.com/rstudio/connectapi/pull/164))
+([#164](https://github.com/posit-dev/connectapi/pull/164))
 - Fix typo in `min_data_version` parameter for usage data functions
-([#166](https://github.com/rstudio/connectapi/pull/166))
+([#166](https://github.com/posit-dev/connectapi/pull/166))
 - Bump Connect tested version to 2022.09.0
-  ([#170](https://github.com/rstudio/connectapi/pull/170))
+  ([#170](https://github.com/posit-dev/connectapi/pull/170))
 
 # connectapi 0.1.1.1
 
@@ -154,7 +154,7 @@
 
 - BREAKING: the following functions now require RStudio Connect 1.8.6 or later
 (because they are no longer experimental, as of that release).
-([#128](https://github.com/rstudio/connectapi/pulls/12))
+([#128](https://github.com/posit-dev/connectapi/pulls/12))
     - `set_vanity_url()`, `get_vanity_url()`, `swap_vanity_url()`
     - `get_tags()`, `get_tag_data()`, `get_content_tags()`, `create_tag()`,
     `create_tag_tree()`, `delete_tag()`, `get_content_tags()`,
@@ -165,16 +165,16 @@
 - BREAKING: `Connect$new()` now takes a `server` argument (instead of `host`)
     - The same is true of the `connect()` function, although we warn about
     argument deprecation in that case.
-    ([#125](https://github.com/rstudio/connectapi/pulls/125))
+    ([#125](https://github.com/posit-dev/connectapi/pulls/125))
 - BREAKING: `set_environment_new()` and `set_environment_remove()` no longer
   take a `.version` argument, and output data structure is a bit different (a
   list of names). They now use the public API, which changes the interface a bit.
   Also, intricacies of how to set / remove environment variables are changed (i.e.
   setting `VAR=NA` will remove `VAR`).
-  ([#141](https://github.com/rstudio/connectapi/pull/141))
+  ([#141](https://github.com/posit-dev/connectapi/pull/141))
 - BREAKING: `get_vanity_url()` and `set_vanity_url()` are now no longer
   experimental functions.
-  ([#113](https://github.com/rstudio/connectapi/pulls/113)) However:
+  ([#113](https://github.com/posit-dev/connectapi/pulls/113)) However:
     - `get_vanity_url()` now returns a character string representing the vanity
     url in use (or NULL if not defined)
     - `set_vanity_url()` still returns a `Vanity` R6 object, but
@@ -184,15 +184,15 @@
 - BREAKING: Several `content_*` and other APIs have moved from experimental to
   "v1" variants. This means they have stabilized, but with several subtle breaking
   changes that could impact your scripts.
-  ([#115](https://github.com/rstudio/connectapi/pulls/115))
+  ([#115](https://github.com/posit-dev/connectapi/pulls/115))
     - i.e. `bundle_id` has become `id` in some response data. In others, `url` has become `content_url`.
     - The R6 method `content$get_bundles()` no longer takes a `page_number`
     argument, and the `get_bundles(limit)` argument is now deprecated
-    ([#129](https://github.com/rstudio/connectapi/pulls/129))
+    ([#129](https://github.com/posit-dev/connectapi/pulls/129))
     - `Connect$download_bundle` is now deprecated in favor of
     `Content$bundle_download()`, and `delete_bundle()` now takes a `Content`
     item instead of `Connect`.
-    ([#153](https://github.com/rstudio/connectapi/pull/153))
+    ([#153](https://github.com/posit-dev/connectapi/pull/153))
 - BREAKING: `acl_*()` functions are deprecated in favor of
   `get_content_permissions()`, `content_add_user()`, and friends.
 - BREAKING: `Connect$PUT()`, `Connect$POST()` and `Connect$PATCH()` endpoints
@@ -203,29 +203,29 @@
 ### Other Changes
 
 - `users_create_remote()` gains an `exact` argument to simplify complex cases
-  ([#135](https://github.com/rstudio/connectapi/issues/135)). Long term, we should
+  ([#135](https://github.com/posit-dev/connectapi/issues/135)). Long term, we should
   solicit feedback on whether this function attempts to do too much.
 - Add helpers for common content modification actions: `content_update()`,
   `content_update_access_type()` and `content_update_owner()`
 - Fix an issue with relative paths in `bundle_dir()`
   ([`@slodge`](https://github.com/slodge))
-  ([#118](https://github.com/rstudio/connectapi/issues/118),
-  [#121](https://github.com/rstudio/connectapi/issues/121))
+  ([#118](https://github.com/posit-dev/connectapi/issues/118),
+  [#121](https://github.com/posit-dev/connectapi/issues/121))
 - Add `overwrite=` parameter to `download_bundle()`
 - Add HTTP request customization options, and related documentation
-  ([#101](https://github.com/rstudio/connectapi/pull/101))
-- Add git deployment ([#112](https://github.com/rstudio/connectapi/issues/112))
+  ([#101](https://github.com/posit-dev/connectapi/pull/101))
+- Add git deployment ([#112](https://github.com/posit-dev/connectapi/issues/112))
 - Switch `Task` class to `ContentTask`
     - R6 does not support multiple inheritance, so we keep the `Task` interface up-to-date on
       `ContentTask` and `VariantTask` manually
 - Improve several print methods
-([#18](https://github.com/rstudio/connectapi/issues/18),
-[#19](https://github.com/rstudio/connectapi/issues/19))
+([#18](https://github.com/posit-dev/connectapi/issues/18),
+[#19](https://github.com/posit-dev/connectapi/issues/19))
 - Protect against bad bundles
-([#13](https://github.com/rstudio/connectapi/issues/13))
-- Error if an empty API key is defined ([#16](https://github.com/rstudio/connectapi/issues/16))
+([#13](https://github.com/posit-dev/connectapi/issues/13))
+- Error if an empty API key is defined ([#16](https://github.com/posit-dev/connectapi/issues/16))
 - Add a few `content_list_*` helpers
-  ([#130](https://github.com/rstudio/connectapi/pulls/130)):
+  ([#130](https://github.com/posit-dev/connectapi/pulls/130)):
   - `content_list_with_permissions` returns a `content_list` with a "permission"
     column that includes who has access
   - `content_list_by_tag` allows fetching just a `content_list` for a particular tag
@@ -233,7 +233,7 @@
     whether a user or group GUID has access
 - Add a `user_guid_from_username()` function to convert `session$user` or other
   usernames to a user GUID
-  ([#130](https://github.com/rstudio/connectapi/pulls/130))
+  ([#130](https://github.com/posit-dev/connectapi/pulls/130))
 
 # connectapi 0.1.0.9018
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -204,5 +204,5 @@ Please open an issue or PR! We would love to have your contribution!
 ## Code of Conduct
 
 Please note that the connectapi project is released with a [Contributor Code of
-Conduct](https://pkgs.rstudio.com/connectapi/CODE_OF_CONDUCT.html). By
+Conduct](https://posit-dev.github.io/connectapi/CODE_OF_CONDUCT.html). By
 contributing to this project, you agree to abide by its terms.

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,8 +16,8 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html#maturing)
 [![CRAN status](https://www.r-pkg.org/badges/version/connectapi)](https://cran.r-project.org/package=connectapi)
-[![Codecov test coverage](https://codecov.io/gh/rstudio/connectapi/branch/main/graph/badge.svg)](https://app.codecov.io/gh/rstudio/connectapi?branch=main)
-[![R build status](https://github.com/rstudio/connectapi/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/connectapi/actions)
+[![Codecov test coverage](https://codecov.io/gh/posit-dev/connectapi/branch/main/graph/badge.svg)](https://app.codecov.io/gh/posit-dev/connectapi?branch=main)
+[![R build status](https://github.com/posit-dev/connectapi/workflows/R-CMD-check/badge.svg)](https://github.com/posit-dev/connectapi/actions)
 <!-- badges: end -->
 
 # connectapi <img src='man/figures/logo.svg' align="right" height="139" />
@@ -38,7 +38,7 @@ install.packages("connectapi")
 To install the development version:
 
 ```r
-remotes::install_github('rstudio/connectapi')
+remotes::install_github('posit-dev/connectapi')
 ```
 
 ## Client

--- a/README.md
+++ b/README.md
@@ -209,5 +209,5 @@ Please open an issue or PR! We would love to have your contribution!
 
 Please note that the connectapi project is released with a [Contributor
 Code of
-Conduct](https://pkgs.rstudio.com/connectapi/CODE_OF_CONDUCT.html). By
+Conduct](https://posit-dev.github.io/connectapi/CODE_OF_CONDUCT.html). By
 contributing to this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lif
 [![CRAN
 status](https://www.r-pkg.org/badges/version/connectapi)](https://cran.r-project.org/package=connectapi)
 [![Codecov test
-coverage](https://codecov.io/gh/rstudio/connectapi/branch/main/graph/badge.svg)](https://app.codecov.io/gh/rstudio/connectapi?branch=main)
+coverage](https://codecov.io/gh/posit-dev/connectapi/branch/main/graph/badge.svg)](https://app.codecov.io/gh/posit-dev/connectapi?branch=main)
 [![R build
-status](https://github.com/rstudio/connectapi/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/connectapi/actions)
+status](https://github.com/posit-dev/connectapi/workflows/R-CMD-check/badge.svg)](https://github.com/posit-dev/connectapi/actions)
 <!-- badges: end -->
 
 # connectapi <img src='man/figures/logo.svg' align="right" height="139" />
@@ -32,7 +32,7 @@ install.packages("connectapi")
 To install the development version:
 
 ``` r
-remotes::install_github('rstudio/connectapi')
+remotes::install_github('posit-dev/connectapi')
 ```
 
 ## Client

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://pkgs.rstudio.com/connectapi/
+url: https://posit-dev.github.io/connectapi/
 
 template:
   bootstrap: 5

--- a/tests/integrated/test-git.R
+++ b/tests/integrated/test-git.R
@@ -7,7 +7,7 @@ test_that("git deployment works", {
   scoped_experimental_silence()
   cont0 <- deploy_repo(
     test_conn_1,
-    "https://github.com/rstudio/connectapi",
+    "https://github.com/posit-dev/connectapi",
     "main",
     "tests/testthat/examples/static"
   )
@@ -17,7 +17,7 @@ test_that("git deployment works", {
   new_name <- uuid::UUIDgenerate()
   cont1 <- deploy_repo(
     test_conn_1,
-    "https://github.com/rstudio/connectapi",
+    "https://github.com/posit-dev/connectapi",
     "main",
     "tests/testthat/examples/static",
     new_name,
@@ -48,7 +48,7 @@ test_that("repo_check_branches works", {
     "not found"
   )
 
-  br <- repo_check_branches(test_conn_1, "https://github.com/rstudio/connectapi")
+  br <- repo_check_branches(test_conn_1, "https://github.com/posit-dev/connectapi")
   expect_true("main" %in% br)
 })
 
@@ -59,7 +59,7 @@ test_that("repo_check_branches_ref works", {
     "not found"
   )
 
-  br <- repo_check_branches_ref(test_conn_1, "https://github.com/rstudio/connectapi")
+  br <- repo_check_branches_ref(test_conn_1, "https://github.com/posit-dev/connectapi")
   expect_type(br, "character")
   expect_true("main" %in% names(br))
   expect_false("main" %in% br)
@@ -73,7 +73,7 @@ test_that("repo_check_manifest_dirs works", {
     "not found"
   )
 
-  drs <- repo_check_manifest_dirs(test_conn_1, "https://github.com/rstudio/connectapi", "main")
+  drs <- repo_check_manifest_dirs(test_conn_1, "https://github.com/posit-dev/connectapi", "main")
   expect_true("tests/testthat/examples/static" %in% drs)
 })
 
@@ -83,7 +83,7 @@ test_that("deploy_repo_enable works", {
   new_name <- uuid::UUIDgenerate()
   cont1 <- deploy_repo(
     test_conn_1,
-    "https://github.com/rstudio/connectapi",
+    "https://github.com/posit-dev/connectapi",
     "main",
     "tests/testthat/examples/static",
     new_name,
@@ -109,7 +109,7 @@ test_that("deploy_repo_update works", {
   new_name <- uuid::UUIDgenerate()
   cont1 <- deploy_repo(
     test_conn_1,
-    "https://github.com/rstudio/connectapi",
+    "https://github.com/posit-dev/connectapi",
     "main",
     "tests/testthat/examples/static",
     new_name,
@@ -124,7 +124,7 @@ test_that("deploy_repo_update works", {
   wrong_branch <- uuid::UUIDgenerate()
   cont2 <- deploy_repo(
     test_conn_1,
-    "https://github.com/rstudio/connectapi",
+    "https://github.com/posit-dev/connectapi",
     "master-not-a-real-branch",
     "tests/testthat/examples/static",
     wrong_branch,

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -8,7 +8,7 @@ without_internet({
   test_that("Query params to repo_account", {
     con <- Connect$new(server = "https://connect.example", api_key = "fake")
     expect_GET(
-      con$repo_account("https://github.com/rstudio/connectapi"),
+      con$repo_account("https://github.com/posit-dev/connectapi"),
       repo_path("account?url=https%3A%2F%2Fgithub.com")
     )
     expect_error(
@@ -20,7 +20,7 @@ without_internet({
   test_that("Query params to repo_branches", {
     con <- Connect$new(server = "https://connect.example", api_key = "fake")
     expect_GET(
-      con$repo_branches("https://github.com/rstudio/connectapi"),
+      con$repo_branches("https://github.com/posit-dev/connectapi"),
       repo_path("branches?url=https%3A%2F%2Fgithub.com%2Frstudio%2Fconnectapi")
     )
   })
@@ -28,7 +28,7 @@ without_internet({
   test_that("Query params to repo_manifest_dirs", {
     con <- Connect$new(server = "https://connect.example", api_key = "fake")
     expect_GET(
-      con$repo_manifest_dirs("https://github.com/rstudio/connectapi", "main"),
+      con$repo_manifest_dirs("https://github.com/posit-dev/connectapi", "main"),
       repo_path("manifest-dirs?url=https%3A%2F%2Fgithub.com%2Frstudio%2Fconnectapi&branch=main")
     )
   })

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -21,7 +21,7 @@ without_internet({
     con <- Connect$new(server = "https://connect.example", api_key = "fake")
     expect_GET(
       con$repo_branches("https://github.com/posit-dev/connectapi"),
-      repo_path("branches?url=https%3A%2F%2Fgithub.com%2Frstudio%2Fconnectapi")
+      repo_path("branches?url=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fconnectapi")
     )
   })
 
@@ -29,7 +29,7 @@ without_internet({
     con <- Connect$new(server = "https://connect.example", api_key = "fake")
     expect_GET(
       con$repo_manifest_dirs("https://github.com/posit-dev/connectapi", "main"),
-      repo_path("manifest-dirs?url=https%3A%2F%2Fgithub.com%2Frstudio%2Fconnectapi&branch=main")
+      repo_path("manifest-dirs?url=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fconnectapi&branch=main")
     )
   })
 })


### PR DESCRIPTION
Related to #352 (does not close)

Outstanding problems

- [x] codecov.io needs to be set up with the new URL ([1](https://github.com/posit-dev/connectapi/pull/358#discussion_r1904258869), [2](https://github.com/posit-dev/connectapi/pull/358#discussion_r1904260494))
- [x] Some tests are failing with the new URLs: `Query params to repo_branches`, `Query params to repo_manifest_dirs`
- [x] Possibly remove issue links from NEWS.md