### PR TITLE
feat: add support for visitor api key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 - New `get_job_list()` function returns a list of jobs for a content item.
   (#341)
 - New `token` parameter to `connect()` function allows you to create a Connect
-  client with permissions scoped to the content viewer when running on a Connect
+  client with permissions scoped to the content visitor when running on a Connect
   server. (#362)
 
 ## Newly deprecated

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
   (#341)
 - New `get_job_list()` function returns a list of jobs for a content item.
   (#341)
+- New `token` parameter to `connect()` function allows you to create a Connect
+  client with permissions scoped to the content viewer when running on a Connect
+  server. (#362)
 
 ## Newly deprecated
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -970,9 +970,9 @@ connect <- function(
         user_session_token = token,
         requested_token_type = "urn:posit:connect:api-key"
       )
-      con <- Connect$new(server = server, api_key = visitor_creds$access_token)
+      con <- connect(server = server, api_key = visitor_creds$access_token)
     } else {
-      con <- Connect$new(server = server, api_key = token_fallback_api_key)
+      con <- connect(server = server, api_key = token_fallback_api_key)
       message(paste0(
         "Called with `token` but not running on Connect. ",
         "Continuing with fallback API key."
@@ -1000,8 +1000,6 @@ connect <- function(
 
   con
 }
-
-# viewer_client <- function(access_token)
 
 check_debug <- function(res) {
   # Check for deprecation warnings from the server.

--- a/R/connect.R
+++ b/R/connect.R
@@ -920,6 +920,7 @@ Connect <- R6::R6Class(
 connect <- function(
     server = Sys.getenv(paste0(prefix, "_SERVER"), NA_character_),
     api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
+    token = NULL,
     prefix = "CONNECT",
     ...,
     .check_is_fatal = TRUE) {
@@ -932,6 +933,15 @@ connect <- function(
     }
   }
   con <- Connect$new(server = server, api_key = api_key)
+
+  if (!is.null(token)) {
+    viewer_creds <- get_oauth_credentials(
+      con,
+      user_session_token = token,
+      requested_token_type = "urn:posit:connect:api-key"
+    )
+    con <- Connect$new(server = server, api_key = viewer_creds$access_token)
+  }
 
   tryCatch(
     {

--- a/R/connect.R
+++ b/R/connect.R
@@ -963,7 +963,7 @@ connect <- function(
 
   if (!missing(token)) {
     error_if_less_than(con$version, "2025.01.0")
-    if (Sys.getenv("RSTUDIO_PRODUCT") == "CONNECT") {
+    if (on_connect()) {
       message()
       visitor_creds <- get_oauth_credentials(
         con,

--- a/R/connect.R
+++ b/R/connect.R
@@ -950,6 +950,7 @@ connect <- function(
   con <- Connect$new(server = server, api_key = api_key)
 
   if (!missing(token)) {
+    error_if_less_than(con$version, "2025.01.0")
     if (Sys.getenv("RSTUDIO_PRODUCT") == "CONNECT") {
       message()
       visitor_creds <- get_oauth_credentials(

--- a/R/connect.R
+++ b/R/connect.R
@@ -896,7 +896,7 @@ Connect <- R6::R6Class(
 #' `CONNECT_SERVER` and `CONNECT_API_KEY` variables. The API key's permissions
 #' are scoped to the publishing user's account.
 #'
-#' To create a client with permissions scoped to the content viewer's account,
+#' To create a client with permissions scoped to the content visitor's account,
 #' call `connect()` passing a user session token from content session headers
 #' to the `token` argument. To do this, you must first add a Connect API
 #' integration in your published content's Access sidebar.
@@ -906,7 +906,7 @@ Connect <- R6::R6Class(
 #' @param api_key The API Key to authenticate to Posit Connect with. Defaults
 #'   to environment variable CONNECT_API_KEY
 #' @param token Optional. A user session token. When running on a Connect server,
-#'   creates a client using the content viewer's account. Running locally, the
+#'   creates a client using the content visitor's account. Running locally, the
 #'   created client uses the provided API key.
 #' @param token_fallback_api_key Optional. When a `token` is provided, but
 #'   content is running locally, this API key is used to create the client.
@@ -931,8 +931,8 @@ Connect <- R6::R6Class(
 #' token <- session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN
 #' client <- connect(token = token)
 #'
-#' # Use with a differently-scoped API key
-#' fallback_key <- Sys.getenv("VIEWER_SCOPED_API_KEY")
+#' # Test locally with an API key using a different role.
+#' fallback_key <- Sys.getenv("VIEWER_ROLE_API_KEY")
 #' client <- connect(token = token, token_fallback_api_key = fallback_key)
 #' }
 #'

--- a/R/connect.R
+++ b/R/connect.R
@@ -947,7 +947,7 @@ connect <- function(
     server = Sys.getenv(paste0(prefix, "_SERVER"), NA_character_),
     api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
     token,
-    fallback_visitor_api_key = api_key,
+    token_fallback_api_key = api_key,
     prefix = "CONNECT",
     ...,
     .check_is_fatal = TRUE) {
@@ -972,7 +972,7 @@ connect <- function(
       )
       con <- Connect$new(server = server, api_key = visitor_creds$access_token)
     } else {
-      con <- Connect$new(server = server, api_key = fallback_visitor_api_key)
+      con <- Connect$new(server = server, api_key = token_fallback_api_key)
       message(paste0(
         "Called with `token` but not running on Connect. ",
         "Continuing with fallback API key."

--- a/R/get.R
+++ b/R/get.R
@@ -579,14 +579,14 @@ get_procs <- function(src) {
   return(tbl_data)
 }
 
-#' Perform an OAuth credential exchange to obtain a viewer's OAuth access token.
+#' Perform an OAuth credential exchange to obtain a visitor's OAuth access token.
 #'
 #' @param connect A Connect R6 object.
-#' @param user_session_token The content viewer's session token. This token
+#' @param user_session_token The content visitor's session token. This token
 #' can only be obtained when the content is running on a Connect server. The token
 #' identifies the user who is viewing the content interactively on the Connect server.
 #' @param requested_token_type Optional. You may pass `"urn:posit:connect:api-key"` to
-#' request an ephemeral Connect API key scoped to the content viewer's account.
+#' request an ephemeral Connect API key scoped to the content visitor's account.
 #'
 #'
 #' Read this value from the HTTP header: `Posit-Connect-User-Session-Token`

--- a/R/get.R
+++ b/R/get.R
@@ -585,6 +585,9 @@ get_procs <- function(src) {
 #' @param user_session_token The content viewer's session token. This token
 #' can only be obtained when the content is running on a Connect server. The token
 #' identifies the user who is viewing the content interactively on the Connect server.
+#' @param requested_token_type Optional. You may pass `"urn:posit:connect:api-key"` to
+#' request an ephemeral Connect API key scoped to the content viewer's account.
+#'
 #'
 #' Read this value from the HTTP header: `Posit-Connect-User-Session-Token`
 #'

--- a/R/get.R
+++ b/R/get.R
@@ -612,13 +612,14 @@ get_procs <- function(src) {
 #' for more information.
 #'
 #' @export
-get_oauth_credentials <- function(connect, user_session_token) {
+get_oauth_credentials <- function(connect, user_session_token, requested_token_type = NULL) {
   validate_R6_class(connect, "Connect")
   url <- v1_url("oauth", "integrations", "credentials")
   body <- list(
     grant_type = "urn:ietf:params:oauth:grant-type:token-exchange",
     subject_token_type = "urn:posit:connect:user-session-token",
-    subject_token = user_session_token
+    subject_token = user_session_token,
+    requested_token_type = requested_token_type
   )
   connect$POST(
     url,

--- a/R/utils.R
+++ b/R/utils.R
@@ -194,3 +194,9 @@ endpoint_does_not_exist <- function(res) {
       !("code" %in% names(httr::content(res, as = "parsed")))
   )
 }
+
+# Returns `TRUE` if we're running on Connect as determined by the
+# `RSTUDIO_PRODUCT` env var, else `FALSE`.
+on_connect <- function() {
+  Sys.getenv("RSTUDIO_PRODUCT") == "CONNECT"
+}

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -8,6 +8,7 @@ connect(
   server = Sys.getenv(paste0(prefix, "_SERVER"), NA_character_),
   api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
   prefix = "CONNECT",
+  token,
   ...,
   .check_is_fatal = TRUE
 )
@@ -21,6 +22,10 @@ to environment variable CONNECT_API_KEY}
 
 \item{prefix}{The prefix used to determine environment variables}
 
+\item{token}{Optional. A user session token. When running on a Connect server,
+creates a client using the content viewer's account. Running locally, the
+created client uses the provided API key.}
+
 \item{...}{Additional arguments. Not used at present}
 
 \item{.check_is_fatal}{Whether to fail if "check" requests fail. Useful in
@@ -31,13 +36,26 @@ succeed.}
 A Posit Connect R6 object that can be passed along to methods
 }
 \description{
-Creates a connection to Posit Connect using the server URL and an api key.
+Creates a connection to Posit Connect using the server URL and an API key.
 Validates the connection and checks that the version of the server is
 compatible with the current version of the package.
 }
+\details{
+When running on Connect, the client's environment will contain default
+\code{CONNECT_SERVER} and \code{CONNECT_API_KEY} variables. The API key's permissions
+will be scoped to the publishing user's account.
+
+To create a client with permissions scoped to the content viewer's account,
+call \code{connect()} passing a user session token from content session headers
+to the \code{token} argument. To do this, you must first add a Connect API
+integration in your published content's Access sidebar.
+}
 \examples{
 \dontrun{
-connect()
+client <- connect()
+
+# Running on Connect, create a client using the content visitor's account.
+client <- connect(token = session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN)
 }
 
 \dontshow{if (identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -8,7 +8,7 @@ connect(
   server = Sys.getenv(paste0(prefix, "_SERVER"), NA_character_),
   api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
   token,
-  token_fallback_api_key = api_key,
+  token_local_testing_key = api_key,
   prefix = "CONNECT",
   ...,
   .check_is_fatal = TRUE
@@ -22,13 +22,14 @@ variable CONNECT_SERVER}
 to environment variable CONNECT_API_KEY}
 
 \item{token}{Optional. A user session token. When running on a Connect server,
-creates a client using the content viewer's account. Running locally, the
+creates a client using the content visitor's account. Running locally, the
 created client uses the provided API key.}
 
-\item{token_fallback_api_key}{Optional. When a \code{token} is provided, but
-content is running locally, this API key is used to create the client.
-By default, the primary \code{api_key} is used, but by providing a different
-key you can test a visitor client with differently-scoped permissions.}
+\item{token_local_testing_key}{Optional. Only used when not running on
+Connect and a \code{token} is provided. By default, the function returns a
+\code{Connect} object using the \code{api_key}. By providing a different
+key here you can test a visitor client with differently-scoped
+permissions.}
 
 \item{prefix}{The prefix used to determine environment variables}
 
@@ -51,7 +52,7 @@ When running on Connect, the client's environment will contain default
 \code{CONNECT_SERVER} and \code{CONNECT_API_KEY} variables. The API key's permissions
 are scoped to the publishing user's account.
 
-To create a client with permissions scoped to the content viewer's account,
+To create a client with permissions scoped to the content visitor's account,
 call \code{connect()} passing a user session token from content session headers
 to the \code{token} argument. To do this, you must first add a Connect API
 integration in your published content's Access sidebar.
@@ -66,9 +67,9 @@ client <- connect()
 token <- session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN
 client <- connect(token = token)
 
-# Use with a differently-scoped API key
-fallback_key <- Sys.getenv("VIEWER_SCOPED_API_KEY")
-client <- connect(token = token, token_fallback_api_key = fallback_key)
+# Test locally with an API key using a different role.
+fallback_key <- Sys.getenv("VIEWER_ROLE_API_KEY")
+client <- connect(token = token, token_local_testing_key = fallback_key)
 }
 
 \dontshow{if (identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -7,8 +7,9 @@
 connect(
   server = Sys.getenv(paste0(prefix, "_SERVER"), NA_character_),
   api_key = Sys.getenv(paste0(prefix, "_API_KEY"), NA_character_),
-  prefix = "CONNECT",
   token,
+  token_fallback_api_key = api_key,
+  prefix = "CONNECT",
   ...,
   .check_is_fatal = TRUE
 )
@@ -20,11 +21,16 @@ variable CONNECT_SERVER}
 \item{api_key}{The API Key to authenticate to Posit Connect with. Defaults
 to environment variable CONNECT_API_KEY}
 
-\item{prefix}{The prefix used to determine environment variables}
-
 \item{token}{Optional. A user session token. When running on a Connect server,
 creates a client using the content viewer's account. Running locally, the
 created client uses the provided API key.}
+
+\item{token_fallback_api_key}{Optional. When a \code{token} is provided, but
+content is running locally, this API key is used to create the client.
+By default, the primary \code{api_key} is used, but by providing a different
+key you can test a visitor client with differently-scoped permissions.}
+
+\item{prefix}{The prefix used to determine environment variables}
 
 \item{...}{Additional arguments. Not used at present}
 
@@ -43,7 +49,7 @@ compatible with the current version of the package.
 \details{
 When running on Connect, the client's environment will contain default
 \code{CONNECT_SERVER} and \code{CONNECT_API_KEY} variables. The API key's permissions
-will be scoped to the publishing user's account.
+are scoped to the publishing user's account.
 
 To create a client with permissions scoped to the content viewer's account,
 call \code{connect()} passing a user session token from content session headers
@@ -54,8 +60,15 @@ integration in your published content's Access sidebar.
 \dontrun{
 client <- connect()
 
-# Running on Connect, create a client using the content visitor's account.
-client <- connect(token = session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN)
+# Running in Connect, create a client using the content visitor's account.
+# This example assumes code is being executed in a Shiny app's `server`
+# function with a `session` object available.
+token <- session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN
+client <- connect(token = token)
+
+# Use with a differently-scoped API key
+fallback_key <- Sys.getenv("VIEWER_SCOPED_API_KEY")
+client <- connect(token = token, token_fallback_api_key = fallback_key)
 }
 
 \dontshow{if (identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/connectapi-package.Rd
+++ b/man/connectapi-package.Rd
@@ -16,17 +16,17 @@ Provides a helpful 'R6' class and methods for interacting with the 'Posit Connec
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://pkgs.rstudio.com/connectapi/}
-  \item \url{https://github.com/rstudio/connectapi}
-  \item Report bugs at \url{https://github.com/rstudio/connectapi/issues}
+  \item \url{https://posit-dev.github.io/connectapi/}
+  \item \url{https://github.com/posit-dev/connectapi}
+  \item Report bugs at \url{https://github.com/posit-dev/connectapi/issues}
 }
 
 
 Useful links:
 \itemize{
-  \item \url{https://pkgs.rstudio.com/connectapi/}
-  \item \url{https://github.com/rstudio/connectapi}
-  \item Report bugs at \url{https://github.com/rstudio/connectapi/issues}
+  \item \url{https://posit-dev.github.io/connectapi/}
+  \item \url{https://github.com/posit-dev/connectapi}
+  \item Report bugs at \url{https://github.com/posit-dev/connectapi/issues}
 }
 
 }

--- a/man/get_oauth_credentials.Rd
+++ b/man/get_oauth_credentials.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/get.R
 \name{get_oauth_credentials}
 \alias{get_oauth_credentials}
-\title{Perform an OAuth credential exchange to obtain a viewer's OAuth access token.}
+\title{Perform an OAuth credential exchange to obtain a visitor's OAuth access token.}
 \usage{
 get_oauth_credentials(connect, user_session_token, requested_token_type = NULL)
 }
 \arguments{
 \item{connect}{A Connect R6 object.}
 
-\item{user_session_token}{The content viewer's session token. This token
+\item{user_session_token}{The content visitor's session token. This token
 can only be obtained when the content is running on a Connect server. The token
 identifies the user who is viewing the content interactively on the Connect server.}
 
 \item{requested_token_type}{Optional. You may pass \code{"urn:posit:connect:api-key"} to
-request an ephemeral Connect API key scoped to the content viewer's account.
+request an ephemeral Connect API key scoped to the content visitor's account.
 
 Read this value from the HTTP header: \code{Posit-Connect-User-Session-Token}}
 }
@@ -22,7 +22,7 @@ Read this value from the HTTP header: \code{Posit-Connect-User-Session-Token}}
 The OAuth credential exchange response.
 }
 \description{
-Perform an OAuth credential exchange to obtain a viewer's OAuth access token.
+Perform an OAuth credential exchange to obtain a visitor's OAuth access token.
 }
 \details{
 Please see https://docs.posit.co/connect/user/oauth-integrations/#obtaining-a-viewer-oauth-access-token

--- a/man/get_oauth_credentials.Rd
+++ b/man/get_oauth_credentials.Rd
@@ -11,7 +11,10 @@ get_oauth_credentials(connect, user_session_token, requested_token_type = NULL)
 
 \item{user_session_token}{The content viewer's session token. This token
 can only be obtained when the content is running on a Connect server. The token
-identifies the user who is viewing the content interactively on the Connect server.
+identifies the user who is viewing the content interactively on the Connect server.}
+
+\item{requested_token_type}{Optional. You may pass \code{"urn:posit:connect:api-key"} to
+request an ephemeral Connect API key scoped to the content viewer's account.
 
 Read this value from the HTTP header: \code{Posit-Connect-User-Session-Token}}
 }

--- a/man/get_oauth_credentials.Rd
+++ b/man/get_oauth_credentials.Rd
@@ -4,7 +4,7 @@
 \alias{get_oauth_credentials}
 \title{Perform an OAuth credential exchange to obtain a viewer's OAuth access token.}
 \usage{
-get_oauth_credentials(connect, user_session_token)
+get_oauth_credentials(connect, user_session_token, requested_token_type = NULL)
 }
 \arguments{
 \item{connect}{A Connect R6 object.}

--- a/tests/testthat/2024.08.0/__api__/v1/oauth/integrations/credentials-a1e6cf-POST.json
+++ b/tests/testthat/2024.08.0/__api__/v1/oauth/integrations/credentials-a1e6cf-POST.json
@@ -1,0 +1,5 @@
+{
+    "access_token": "viewer-api-key",
+    "issued_token_type": "urn:posit:connect:api-key",
+    "token_type": "Key"
+}

--- a/tests/testthat/2024.08.0/__api__/v1/oauth/integrations/credentials-a1e6cf-POST.json
+++ b/tests/testthat/2024.08.0/__api__/v1/oauth/integrations/credentials-a1e6cf-POST.json
@@ -1,5 +1,5 @@
 {
-    "access_token": "viewer-api-key",
+    "access_token": "visitor-api-key",
     "issued_token_type": "urn:posit:connect:api-key",
     "token_type": "Key"
 }

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -116,7 +116,7 @@ test_that("client$version is returns version when server settings exposes it", {
   })
 })
 
-test_that("Viewer client can successfully be created running on Connect", {
+test_that("Visitor client can successfully be created running on Connect", {
   with_mock_api({
     withr::local_envvar(
       CONNECT_SERVER = "https://connect.example",
@@ -132,12 +132,12 @@ test_that("Viewer client can successfully be created running on Connect", {
     )
     expect_equal(
       client$api_key,
-      "viewer-api-key"
+      "visitor-api-key"
     )
   })
 })
 
-test_that("Viewer client uses fallback api key when running locally", {
+test_that("Visitor client uses fallback api key when running locally", {
   with_mock_api({
     withr::local_envvar(
       CONNECT_SERVER = "https://connect.example",
@@ -176,7 +176,7 @@ test_that("Viewer client uses fallback api key when running locally", {
   })
 })
 
-test_that("Viewer client code path errs with older Connect version", {
+test_that("Visitor client code path errs with older Connect version", {
   with_mock_dir("2024.09.0", {
     withr::local_envvar(
       CONNECT_SERVER = "https://connect.example",

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -161,7 +161,7 @@ test_that("Visitor client uses fallback api key when running locally", {
 
     # With explicitly-defined fallback
     expect_message(
-      client <- connect(token = NULL, token_fallback_api_key = "fallback_fake"),
+      client <- connect(token = NULL, token_local_testing_key = "fallback_fake"),
       "Called with `token` but not running on Connect. Continuing with fallback API key."
     )
 

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -137,16 +137,17 @@ test_that("Viewer client can successfully be created running on Connect", {
   })
 })
 
-test_that("Viewer client uses api key when running locally", {
+test_that("Viewer client uses fallback api key when running locally", {
   with_mock_api({
     withr::local_envvar(
       CONNECT_SERVER = "https://connect.example",
       CONNECT_API_KEY = "fake"
     )
 
+    # With default fallback
     expect_message(
       client <- connect(token = NULL),
-      "Called with `token` but not running on Connect. Continuing with API key."
+      "Called with `token` but not running on Connect. Continuing with fallback API key."
     )
 
     expect_equal(
@@ -156,6 +157,21 @@ test_that("Viewer client uses api key when running locally", {
     expect_equal(
       client$api_key,
       "fake"
+    )
+
+    # With explicitly-defined fallback
+    expect_message(
+      client <- connect(token = NULL, fallback_visitor_api_key = "fallback_fake"),
+      "Called with `token` but not running on Connect. Continuing with fallback API key."
+    )
+
+    expect_equal(
+      client$server,
+      "https://connect.example"
+    )
+    expect_equal(
+      client$api_key,
+      "fallback_fake"
     )
   })
 })

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -115,3 +115,48 @@ test_that("client$version is returns version when server settings exposes it", {
     expect_equal(con$version, "2024.09.0")
   })
 })
+
+test_that("Viewer client can successfully be created running on Connect", {
+  with_mock_api({
+    withr::local_envvar(
+      CONNECT_SERVER = "https://connect.example",
+      CONNECT_API_KEY = "fake",
+      RSTUDIO_PRODUCT = "CONNECT"
+    )
+
+    client <- connect(token = "my-token")
+
+    expect_equal(
+      client$server,
+      "https://connect.example"
+    )
+    expect_equal(
+      client$api_key,
+      "viewer-api-key"
+    )
+  })
+})
+
+test_that("Viewer client uses api key when running locally", {
+  with_mock_api({
+    withr::local_envvar(
+      CONNECT_SERVER = "https://connect.example",
+      CONNECT_API_KEY = "fake"
+    )
+
+    expect_message(
+      client <- zconnect(token = NULL),
+      "Called with `token` but not running on Connect. Continuing with API key."
+    )
+
+    expect_equal(
+      client$server,
+      "https://connect.example"
+    )
+    expect_equal(
+      client$api_key,
+      "fake"
+    )
+  })
+})
+

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -145,7 +145,7 @@ test_that("Viewer client uses api key when running locally", {
     )
 
     expect_message(
-      client <- zconnect(token = NULL),
+      client <- connect(token = NULL),
       "Called with `token` but not running on Connect. Continuing with API key."
     )
 
@@ -160,3 +160,17 @@ test_that("Viewer client uses api key when running locally", {
   })
 })
 
+test_that("Viewer client code path errs with older Connect version", {
+  with_mock_dir("2024.09.0", {
+    withr::local_envvar(
+      CONNECT_SERVER = "https://connect.example",
+      CONNECT_API_KEY = "fake",
+      RSTUDIO_PRODUCT = "CONNECT"
+    )
+
+    expect_error(
+      client <- connect(token = "my-token"),
+      "This feature requires Posit Connect version 2025.01.0 but you are using 2024.09.0"
+    )
+  })
+})

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -161,7 +161,7 @@ test_that("Viewer client uses fallback api key when running locally", {
 
     # With explicitly-defined fallback
     expect_message(
-      client <- connect(token = NULL, fallback_visitor_api_key = "fallback_fake"),
+      client <- connect(token = NULL, token_fallback_api_key = "fallback_fake"),
       "Called with `token` but not running on Connect. Continuing with fallback API key."
     )
 


### PR DESCRIPTION
## Intent

Add the ability to create a Connect client using content visitor-scoped authentication.

Fixes #362

## Approach

Added a token argument to the `connect()` function. When passed a token and running on Connect, performs an OAuth credential exchange request to get a visitor API key and returns a client using that API key instead. When an argument is provided to `token` but code is not running on Connect, prints a message and returns a client using the provided API key.

I considered a few tradeoffs:

- The general convention in R is to indicate optional arguments by giving them a default `NULL` value. This implementation breaks with the convention — `token` argument has no default value, and I use `missing()` to tell if it has been provided.
  - The default value for missing HTTP headers in R is `NULL`, so sticking to convention means that we can't tell the difference between the cases where a user just wants to use the API key, or is using the `token` arg but running the content locally.
  - This is actually _fine_ wrt functionality, because doing this leads to the correct behavior of, when `token` is provided correctly, using the API key locally but using the token on Connect.
  - _However_, I decided to break with the default `NULL` arg convention because this allows us to log a console message when the content is running locally and we see that they provided a NULL arg to `token` and are using the API key.
-  The `token` argument actually comes _before_ the pre-existing `prefix` argument. This is fine, I think: the `prefix` argument would be used when users want to set the env var value of both `server` and `api_key`, the first two arguments, so it should basically _never_ be called with them — which means it would _always_ be called by name and not positionally, and is fine to move. The `token` argument makes more sense to be up front with those two, although it's unlikely to ever be called positionally, because I doubt you'd ever call it and also pass in a `server` URL.
- The new logic was added in the `connect()` function, rather than the Connect object's `Connect$new()` initialization function. This… just made more sense to me. This is logic that wraps the direct initialization of the object.
  - Currently, the way that messaging happens inside `connect()`, when you use a token on Connect, the app logs will contain the line `Defining Connect with the server: {server}` twice. This is because that line is logged from `Connect$new()`. I guess we could move that log line out of that function, but that didn't seem like a huge priority. And technically, both clients _are_ defined, because the first one is used to make the OAuth request.
- I named the arg for the fallback API key `token_fallback_api_key` which is kinda verbose — I wanted to clarify that it wasn't, like, just a fallback API key that's used if the regular `api_key` is not present.
 
## Manual Verification

You can test this with the following Shiny app:

```r
library(shiny)
library(connectapi)

ui <- fluidPage(
  "Publisher",
  verbatimTextOutput("publisher_username"),
  verbatimTextOutput("publisher_api_key"),
  "Viewer",
  verbatimTextOutput("viewer_username"),
  verbatimTextOutput("viewer_api_key")
)

server <- function(input, output, session) {
  # Create a publisher client for comparison. This is not needed to create a viewer client.
  publisher_client <- connect()

  # Read the user-session-token header and create a viewer client
  user_session_token <- session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN
  viewer_client <- connect(token = user_session_token)

  output$publisher_username <- renderText(paste("username:", publisher_client$GET("v1/user")$username))
  output$publisher_api_key <- renderText(paste("api key:", publisher_client$api_key))
  output$viewer_username <- renderText(paste("username:", viewer_client$GET("v1/user")$username))
  output$viewer_api_key <- renderText(paste("api key:", viewer_client$api_key))
}

shinyApp(ui, server)
```

To publish this to Connect with the dev version of `connectapi`:

1. Place this app in a directory in a file named `app.R`.
2. In an R console, run `renv::init()`, `renv::install("posit-dev/connectapi@toph/viewer-api-key")`, and `renv::snapshot()`.
3. Publish to Connect.

## Checklist

- [x] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [x] Does this change need documentation? Have you run `devtools::document()`?
