### PR TITLE
chore: fix linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: local::., any::lintr, any::devtools, any::testthat
+          extra-packages: local::., any::lintr, any::devtools, any::testthat, any::cyclocomp
           needs: lint
 
       - name: Lint

--- a/.lintr
+++ b/.lintr
@@ -3,9 +3,12 @@ linters: linters_with_defaults(
   object_name_linter = object_name_linter(styles = c("snake_case", "symbols", "CamelCase")),
   cyclocomp_linter = cyclocomp_linter(30L),
   object_length_linter(32L),
-  indentation_linter = indentation_linter(hanging_indent_style = "tidy")
+  indentation_linter = indentation_linter(hanging_indent_style = "tidy"),
+  return_linter = NULL
   )
 exclusions: list(
+  "tests/testthat/2024.07.0/",
   "tests/testthat/2024.08.0/",
-  "tests/testthat/2024.09.0/"
+  "tests/testthat/2024.09.0/",
+  "inst/scratch/"
   )


### PR DESCRIPTION
`lintr` v3.2.0 removed a hard dependency on `cyclocomp`, so the cyclocomp linter is failing. This PR installs that package to the lintr CI workflow, and should fix the problem.