### PR TITLE
fix: simplify `get_packages()`

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -830,12 +830,12 @@ Connect <- R6::R6Class(
     #' @param name The package name to filter by.
     #' @param page_number The page number.
     #' @param page_size Page size, max 500.
-    packages = function(name = NULL, page_number = 1, page_size = 500) {
+    packages = function(name = NULL, page_number = 1) {
       url <- v1_url("packages")
       query_params <- list(
         name = name,
         page_number = page_number,
-        page_size = page_size
+        page_size = "1000000"
       )
       self$GET(url, query = query_params)
     },

--- a/R/connect.R
+++ b/R/connect.R
@@ -826,16 +826,16 @@ Connect <- R6::R6Class(
 
     # packages --------------------------------------------------
 
-    #' @description Get packages.
+    #' @description Get packages. This endpoint is paginated.
     #' @param name The package name to filter by.
-    #' @param page_number The page number.
-    #' @param page_size Page size, max 500.
-    packages = function(name = NULL, page_number = 1) {
+    #' @param page_number Page number.
+    #' @param page_size Page size, default 100000.
+    packages = function(name = NULL, page_number = 1, page_size = 100000) {
       url <- v1_url("packages")
       query_params <- list(
         name = name,
-        page_number = page_number,
-        page_size = "1000000"
+        page_number = format(page_number, scientific = FALSE),
+        page_size = format(page_size, scientific = FALSE)
       )
       self$GET(url, query = query_params)
     },

--- a/R/connect.R
+++ b/R/connect.R
@@ -834,6 +834,9 @@ Connect <- R6::R6Class(
       url <- v1_url("packages")
       query_params <- list(
         name = name,
+        # We use `format()` here because `httr` seems to serialize integers over
+        # 99999 with scientific notation, which causes incorrect query strings.
+        # Finding a more general solution to this is tracked by #379.
         page_number = format(page_number, scientific = FALSE),
         page_size = format(page_size, scientific = FALSE)
       )

--- a/R/get.R
+++ b/R/get.R
@@ -747,9 +747,15 @@ get_runtimes <- function(client, runtimes = NULL) {
 #' @description Get a data frame of package dependencies used by all content
 #' items on the server.
 #'
+#' @usage get_packages(src, name = NULL, page_size = 100000, limit = Inf)
+#'
 #' @param src A `Connect` client object.
 #' @param name Optional package name to filter by. Python package are normalized
 #' during matching; R package names must match exactly.
+#' @param page_size Optional. Integer specifying page size for API
+#' paging.
+#' @param limit Optional. Specify the maximum number of records after which
+#' to cease paging.
 #'
 #' @return A data frame with the following columns:
 #'
@@ -772,13 +778,14 @@ get_runtimes <- function(client, runtimes = NULL) {
 #'
 #' @family packages functions
 #' @export
-get_packages <- function(src, name = NULL) {
+get_packages <- function(src, name = NULL, page_size = 100000, limit = Inf) {
   validate_R6_class(src, "Connect")
   error_if_less_than(src$version, "2024.11.0")
   res <- page_offset(
     src,
     src$packages(
-      name = name
+      name = name,
+      page_size = page_size
     )
   )
   out <- parse_connectapi_typed(res, connectapi_ptypes$packages)

--- a/R/get.R
+++ b/R/get.R
@@ -744,21 +744,12 @@ get_runtimes <- function(client, runtimes = NULL) {
 
 #' All package dependencies on the server
 #'
-#' @description Get a data frame of all package dependencies used by content
+#' @description Get a data frame of package dependencies used by all content
 #' items on the server.
-#'
-#' The `page_size` and `limit` parameters are optional but may be useful during
-#' development, when you're iterating on some code that uses this function.
-#' Behind the scenes, Connect returns packages in pages, and with large or
-#' long-running servers, this can take a while. Setting a `limit` causes
-#' Connect to stop early, giving you incomplete data, but faster.
 #'
 #' @param src A `Connect` client object.
 #' @param name Optional package name to filter by. Python package are normalized
 #' during matching; R package names must match exactly.
-#' @param page_size Optional, max 500. Integer specifying page size for API
-#' paging.
-#' @param limit Optionally specify the maximum number of records to return.
 #'
 #' @return A data frame with the following columns:
 #'
@@ -781,16 +772,14 @@ get_runtimes <- function(client, runtimes = NULL) {
 #'
 #' @family packages functions
 #' @export
-get_packages <- function(src, name = NULL, page_size = 500, limit = Inf) {
+get_packages <- function(src, name = NULL) {
   validate_R6_class(src, "Connect")
   error_if_less_than(src$version, "2024.11.0")
   res <- page_offset(
     src,
     src$packages(
-      name = name,
-      page_size = page_size
-    ),
-    limit = limit
+      name = name
+    )
   )
   out <- parse_connectapi_typed(res, connectapi_ptypes$packages)
 

--- a/R/page.R
+++ b/R/page.R
@@ -69,10 +69,11 @@ page_offset <- function(client, req, limit = Inf) {
 
   req_response <- rlang::eval_tidy(qreq)
   res <- req_response$results
+  total_items <- req_response$total
 
   agg_response <- res
   agg_length <- length(agg_response)
-  while (length(res) > 0 && agg_length < limit) {
+  while (length(res) > 0 && agg_length < limit && agg_length < total_items) {
     prg$tick()
 
     # bump the page number

--- a/man/PositConnect.Rd
+++ b/man/PositConnect.Rd
@@ -1284,9 +1284,9 @@ Get schedules.
 \if{html}{\out{<a id="method-Connect-packages"></a>}}
 \if{latex}{\out{\hypertarget{method-Connect-packages}{}}}
 \subsection{Method \code{packages()}}{
-Get packages.
+Get packages. This endpoint is paginated.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$packages(name = NULL, page_number = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Connect$packages(name = NULL, page_number = 1, page_size = 1e+05)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1294,9 +1294,9 @@ Get packages.
 \describe{
 \item{\code{name}}{The package name to filter by.}
 
-\item{\code{page_number}}{The page number.}
+\item{\code{page_number}}{Page number.}
 
-\item{\code{page_size}}{Page size, max 500.}
+\item{\code{page_size}}{Page size, default 100000.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/PositConnect.Rd
+++ b/man/PositConnect.Rd
@@ -1286,7 +1286,7 @@ Get schedules.
 \subsection{Method \code{packages()}}{
 Get packages.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Connect$packages(name = NULL, page_number = 1, page_size = 500)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Connect$packages(name = NULL, page_number = 1)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/get_packages.Rd
+++ b/man/get_packages.Rd
@@ -4,13 +4,19 @@
 \alias{get_packages}
 \title{All package dependencies on the server}
 \usage{
-get_packages(src, name = NULL)
+get_packages(src, name = NULL, page_size = 100000, limit = Inf)
 }
 \arguments{
 \item{src}{A \code{Connect} client object.}
 
 \item{name}{Optional package name to filter by. Python package are normalized
 during matching; R package names must match exactly.}
+
+\item{page_size}{Optional. Integer specifying page size for API
+paging.}
+
+\item{limit}{Optional. Specify the maximum number of records after which
+to cease paging.}
 }
 \value{
 A data frame with the following columns:

--- a/man/get_packages.Rd
+++ b/man/get_packages.Rd
@@ -4,18 +4,13 @@
 \alias{get_packages}
 \title{All package dependencies on the server}
 \usage{
-get_packages(src, name = NULL, page_size = 500, limit = Inf)
+get_packages(src, name = NULL)
 }
 \arguments{
 \item{src}{A \code{Connect} client object.}
 
 \item{name}{Optional package name to filter by. Python package are normalized
 during matching; R package names must match exactly.}
-
-\item{page_size}{Optional, max 500. Integer specifying page size for API
-paging.}
-
-\item{limit}{Optionally specify the maximum number of records to return.}
 }
 \value{
 A data frame with the following columns:
@@ -33,14 +28,8 @@ this package
 }
 }
 \description{
-Get a data frame of all package dependencies used by content
+Get a data frame of package dependencies used by all content
 items on the server.
-
-The \code{page_size} and \code{limit} parameters are optional but may be useful during
-development, when you're iterating on some code that uses this function.
-Behind the scenes, Connect returns packages in pages, and with large or
-long-running servers, this can take a while. Setting a \code{limit} causes
-Connect to stop early, giving you incomplete data, but faster.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -246,7 +246,7 @@ test_that("Pagination is wired up correctly for packages method", {
       client <- Connect$new(server = "https://connect.example", api_key = "fake")
       expect_GET(
         client$packages(name = "mypkg", page_number = 1),
-        "https://connect.example/__api__/v1/packages?name=mypkg&page_number=1&page_size=1000000"
+        "https://connect.example/__api__/v1/packages?name=mypkg&page_number=1&page_size=100000"
       )
     })
   })

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -200,7 +200,7 @@ test_that("get_packages() works as expected with current return value", {
     "GET", "v1/packages",
     content = list(
       current_page = 1,
-      total = 186690,
+      total = 2,
       results = list(
         list(
           language = "python",
@@ -226,7 +226,7 @@ test_that("get_packages() works as expected with current return value", {
     )
   )
   expect_identical(
-    get_packages(client, page_size = 2, limit = 2),
+    get_packages(client),
     tibble::tibble(
       language = c("python", "python"),
       language_version = c("3.7.6", "3.7.7"),
@@ -245,8 +245,8 @@ test_that("Pagination is wired up correctly for packages method", {
     without_internet({
       client <- Connect$new(server = "https://connect.example", api_key = "fake")
       expect_GET(
-        client$packages(name = "mypkg", page_number = 1, page_size = 50),
-        "https://connect.example/__api__/v1/packages?name=mypkg&page_number=1&page_size=50"
+        client$packages(name = "mypkg", page_number = 1),
+        "https://connect.example/__api__/v1/packages?name=mypkg&page_number=1&page_size=1000000"
       )
     })
   })
@@ -262,7 +262,7 @@ test_that("get_packages() works as expected with `content_guid` names in API res
     "GET", "v1/packages",
     content = list(
       current_page = 1,
-      total = 186690,
+      total = 2,
       results = list(
         list(
           language = "python",
@@ -293,7 +293,7 @@ test_that("get_packages() works as expected with `content_guid` names in API res
   )
 
   expect_identical(
-    get_packages(client, page_size = 2, limit = 2),
+    get_packages(client),
     tibble::tibble(
       language = c("python", "python"),
       language_version = c("3.7.6", "3.7.7"),


### PR DESCRIPTION
## Intent

Simplify `get_packages()`, removing pagination-related parameters.

Fixes #

## Approach

- Internally, use a response limit of 100000 items for the endpoint.
- Remove `page_size` and `limit` from the user-facing function `get_packages()`.
- To fix tests that broke, alter the `page_offset()` function to cease iteration when the total number of aggregated items reaches the total number of items that the server will return. (Previously, it would continue to request a new page until the number of new items was 0, but the responses always contain the total number of items to be returned!)

## Checklist

- [ ] Does this change update `NEWS.md` (referencing the connected issue if necessary)?
- [x] Does this change need documentation? Have you run `devtools::document()`?
