### PR TITLE
Cache timezone response and remove other caller of unversioned API

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -955,7 +955,8 @@ Connect <- R6::R6Class(
     # end --------------------------------------------------------
   ),
   private = list(
-    .version = NULL
+    .version = NULL,
+    .timezones = NULL
   ),
   active = list(
     #' @field version The server version.
@@ -964,6 +965,18 @@ Connect <- R6::R6Class(
         private$.version <- safe_server_version(self)
       }
       private$.version
+    },
+    #' @field timezones The server timezones.
+    timezones = function() {
+      if (is.null(private$.timezones)) {
+        private$.timezones <- tryCatch(
+          self$GET(v1_url("timezones")),
+          error = function(e) {
+            self$GET(unversioned_url("timezones"))
+          }
+        )
+      }
+      private$.timezones
     }
   )
 )

--- a/R/schedule.R
+++ b/R/schedule.R
@@ -129,7 +129,6 @@ VariantSchedule <- R6::R6Class(
           "year" = glue::glue("Every {schdata$N} year{plural}"),
           "Unknown schedule"
         )
-        # TODO: is fetching data during a PRINT a bit overkill?
         tz_offset <- .get_offset(self$get_connect(), rawdata$timezone)
         c(
           desc,
@@ -143,9 +142,7 @@ VariantSchedule <- R6::R6Class(
 )
 
 .get_offset <- function(connect, timezone) {
-  # TODO: some type of cache to reduce churn here?
-  tz <- connect$GET(unversioned_url("timezones"))
-  res <- purrr::keep(tz, ~ .x[["timezone"]] == timezone)
+  res <- purrr::keep(connect$timezones, ~ .x[["timezone"]] == timezone)
   if (length(res) != 1) {
     stop(glue::glue("ERROR: timezone '{timezone}' not found"))
   }
@@ -528,12 +525,7 @@ schedule_describe <- function(.schedule) {
 #' @family schedule functions
 #' @export
 get_timezones <- function(connect) {
-  raw_tz <- tryCatch(
-    connect$GET(v1_url("timezones")),
-    error = function(e) {
-      connect$GET(unversioned_url("timezones"))
-    }
-  )
+  raw_tz <- connect$timezones
 
   tz_values <- purrr::map_chr(raw_tz, ~ .x[["timezone"]])
   tz_display <- purrr::map_chr(

--- a/man/PositConnect.Rd
+++ b/man/PositConnect.Rd
@@ -60,6 +60,8 @@ Other R6 classes:
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
 \item{\code{version}}{The server version.}
+
+\item{\code{timezones}}{The server timezones.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -131,7 +131,7 @@ test_that("parse_connect_rfc3339() handles fractional seconds", {
       "2024-12-06T19:09:29.948070345+0000"
     ),
     format = "%Y-%m-%dT%H:%M:%OS%z",
-    tz = "UTC"
+    tz = Sys.timezone()
   ))
 
   x <- c("2024-12-06T19:09:29.948016766Z", "2024-12-06T19:09:29.948070345Z")


### PR DESCRIPTION
## Intent

Remove the last (unconditional) caller of the unversioned timezones API.

## Approach

Since timezones won't likely change during the course of an R session (and the only calling of this is for printing progress messages, it seems, so whatever), memoize the timezones data on the connect session object, using the approach of trying the v1 API first. Then remove the two places that were calling the API, one of which was not calling the v1 API.

## Checklist

- [x] Does this change need documentation? Have you run `devtools::document()`?
