### PR TITLE
refactor: add unversioned_fallback_url() alias

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -972,7 +972,7 @@ Connect <- R6::R6Class(
         private$.timezones <- tryCatch(
           self$GET(v1_url("timezones")),
           error = function(e) {
-            self$GET(unversioned_url("timezones"))
+            self$GET(unversioned_fallback_url("timezones"))
           }
         )
       }

--- a/R/content.R
+++ b/R/content.R
@@ -112,7 +112,7 @@ Content <- R6::R6Class(
       use_unversioned <- endpoint_does_not_exist(res)
       if (use_unversioned) {
         res <- self$connect$GET(
-          unversioned_url("applications", self$content$guid, "jobs"),
+          unversioned_fallback_url("applications", self$content$guid, "jobs"),
           parser = NULL
         )
       }

--- a/R/schedule.R
+++ b/R/schedule.R
@@ -53,7 +53,7 @@ VariantSchedule <- R6::R6Class(
           app_id = self$get_variant()$app_id,
           variant_id = self$get_variant()$id
         )
-        path <- "schedules"
+        path <- unversioned_url("schedules")
       } else {
         path <- unversioned_url("schedules", self$get_schedule()$id)
       }

--- a/R/thumbnail.R
+++ b/R/thumbnail.R
@@ -35,7 +35,7 @@ get_thumbnail <- function(content, path = NULL) {
   )
   if (httr::status_code(res) == 404) {
     res <- con$GET(
-      unversioned_url("applications", guid, "image"),
+      unversioned_fallback_url("applications", guid, "image"),
       parser = NULL
     )
   }
@@ -105,7 +105,7 @@ delete_thumbnail <- function(content) {
   # https://docs.posit.co/connect/api/#overview--api-error-codes
   if (httr::status_code(res) == 404 && error_code(res) != 17) {
     res <- con$DELETE(
-      unversioned_url("applications", guid, "image"),
+      unversioned_fallback_url("applications", guid, "image"),
       parser = NULL
     )
   }
@@ -152,7 +152,7 @@ has_thumbnail <- function(content) {
   )
   if (httr::status_code(res) == 404) {
     res <- con$GET(
-      unversioned_url("applications", guid, "image"),
+      unversioned_fallback_url("applications", guid, "image"),
       parser = NULL
     )
   }
@@ -219,7 +219,7 @@ set_thumbnail <- function(content, path) {
   )
   if (httr::status_code(res) == 404) {
     res <- con$POST(
-      path = unversioned_url("applications", guid, "image"),
+      path = unversioned_fallback_url("applications", guid, "image"),
       body = httr::upload_file(valid_path),
       parser = NULL
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,6 +7,11 @@ unversioned_url <- function(...) {
   paste(..., sep = "/")
 }
 
+# Make an alias of unversioned_url to help us be able to search for the places
+# where we call the unversioned API, but not be misled by places we've left in
+# for backwards compatibility.
+unversioned_fallback_url <- unversioned_url
+
 valid_page_size <- function(x, min = 1, max = 500) {
   # This could be changed to error if x is outside the range
   min(max(min, x), max)


### PR DESCRIPTION
## Intent

Add an alias to `unversioned_url()` that we can use for the places where we call an old API but only as a fallback when the new API isn't available on the Connect server. By using this, we can more easily find the places where we unconditionally call undocumented APIs by searching the code for `unversioned_url`, which will help us burn down that list.

## Approach

Read the code, replace as needed. There is no behavior change.

