### PR TITLE
refactor: use v1 keys API in integration test setup

### DIFF
--- a/R/utils-ci.R
+++ b/R/utils-ci.R
@@ -221,9 +221,15 @@ create_first_admin <- function(url, user, password, email) {
 
   client$login(user = user, password = password)
 
-  api_key <- client$POST(
-    path = v1_url("users", new_user[["guid"]], "keys"),
-    body = list(name = "first-key")
+  api_key <- tryCatch(
+    client$POST(
+      path = v1_url("users", new_user[["guid"]], "keys"),
+      body = list(name = "first-key")
+    ),
+    error = function(e) {
+      # TODO: rebase after #408 merges. `unversioned_fallback_url()`
+      client$POST(unversioned_url("keys"), body = list(name = "first-key"))
+    }
   )
 
   # Then we return a non-hacky Connect object with the API key

--- a/R/utils-ci.R
+++ b/R/utils-ci.R
@@ -227,8 +227,10 @@ create_first_admin <- function(url, user, password, email) {
       body = list(name = "first-key")
     ),
     error = function(e) {
-      # TODO: rebase after #408 merges. `unversioned_fallback_url()`
-      client$POST(unversioned_url("keys"), body = list(name = "first-key"))
+      client$POST(
+        unversioned_fallback_url("keys"),
+        body = list(name = "first-key")
+      )
     }
   )
 


### PR DESCRIPTION
## Intent

Removes the last caller of this unversioned API. Only used in the integration tests.

## Approach

Switch to `v1/users/guid/keys` where available, falling back to the old one where it doesn't. Some other tidying while in there.

If the integration tests pass, this proves that the fallback works. But until we do #395, we don't have a test run that exercises this. For better or worse, this is test only code.
